### PR TITLE
AttributeError in QUIT handler due to method name mismatch

### DIFF
--- a/kitnirc/client.py
+++ b/kitnirc/client.py
@@ -682,7 +682,7 @@ def _parse_quit(client, command, actor, args):
     client.dispatch_event("QUIT", actor, message)
     for chan in client.server.channels.itervalues():
         if actor.nick in chan.members:
-            chan.remove(actor)
+            chan.remove_user(actor)
             client.dispatch_event("MEMBERS", chan)
 
 


### PR DESCRIPTION
```
ERROR 2014-01-11 20:50:37,481 kitnirc.client:0222 - Error while processing event 'LINE': AttributeError("'Channel' object has no attribute 'remove'",)
Traceback (most recent call last):
  File "/home/shrdlu/.local/lib/python2.7/site-packages/kitnirc/client.py", line 217, in dispatch_event
    if handler(self, *args):
  File "/home/shrdlu/.local/lib/python2.7/site-packages/kitnirc/client.py", line 582, in on_line
    parser(client, command, actor, args)
  File "/home/shrdlu/.local/lib/python2.7/site-packages/kitnirc/client.py", line 685, in _parse_quit
    chan.remove(actor)
AttributeError: 'Channel' object has no attribute 'remove'
```
