### PR TITLE
Include key when joining channels via admintools command.

### DIFF
--- a/kitnirc/contrib/admintools.py
+++ b/kitnirc/contrib/admintools.py
@@ -81,13 +81,13 @@ class AdminModule(Module):
         elif result is False:
             client.reply(recipient, actor, "Sorry, try again.")
 
-        # Suprress further handling of the PRIVMSG event.
+        # Suppress further handling of the PRIVMSG event.
         return True
 
     def join(self, client, args):
         if not args:
             return False
-        if client.join(*args):
+        if client.join(args[0], args[1] if len(args) > 1 else None):
             return True
         else:
             return False


### PR DESCRIPTION
Current version of the admintools join function only passes the channel name to client.join, so channels with keys can't be joined this way. This change makes it pass on all arguments, so "join #somechannel secretkey" will work in channels/PMs from admins.
