### PR TITLE
Add missing attribute prefixes

### DIFF
--- a/kitnirc/contrib/commands.py
+++ b/kitnirc/contrib/commands.py
@@ -41,7 +41,7 @@ class CommandsModule(Module):
 
 
     def __init__(self, *args, **kwargs):
-        super(CommandsModule, self, *args, **kwargs)
+        super(CommandsModule, self).__init__(*args, **kwargs)
         self.prefixes = set()
 
     def start(self, *args, **kwargs):


### PR DESCRIPTION
This attribute was missing, so it would sometimes break. It works now!
